### PR TITLE
chore: replace git-auto-commit-action with git commands

### DIFF
--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -2,6 +2,7 @@ name: Update README
 
 on:
   push:
+    branches: [main]
   schedule:
     - cron: "0 */1 * * *"
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- Replace `stefanzweifel/git-auto-commit-action@v7` with direct git commands
- Preserves same commit message, author, and push behavior
- Keeps `charmbracelet/readme-scribe@master` (no replacement available)

## Test plan

- [ ] Verify README auto-update still commits and pushes when changes exist
- [ ] Verify no commit is created when README is unchanged